### PR TITLE
Include src submodules in setuptools fixing the dists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
 
 extra_options = {
     'package_dir': {'': 'src'},
-    'packages': find_packages(),
+    'packages': find_packages(where='src'),
 }
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Fix #14.
It looks like we need to show where packages can be found if they are in subfolders.